### PR TITLE
fix/4465 add label for max file size -- WIP

### DIFF
--- a/src/fields/file.coffee
+++ b/src/fields/file.coffee
@@ -28,6 +28,8 @@ FormRenderer.Models.ResponseFieldFile = FormRenderer.Models.ResponseField.extend
       10
     else
       1
+  maxSingleFileSize: ->
+    250
 
 FormRenderer.Views.ResponseFieldFile = FormRenderer.Views.ResponseField.extend
   events: _.extend {}, FormRenderer.Views.ResponseField::events,

--- a/src/templates/fields/file.eco
+++ b/src/templates/fields/file.eco
@@ -9,6 +9,10 @@
 
 <% if @model.canAddFile(): %>
   <div class='fr_add_file'>
+    <div class='fr_file_size_limit'>
+      Individual files cannot be larger than <%= @model.maxSingleFileSize() %> MB.
+    </div>
+
     <label for='<%= @domId() %>' class='<%= FormRenderer.BUTTON_CLASS %>'>
       <%= if @model.getFiles().length then FormRenderer.t.upload_another else FormRenderer.t.upload %>
     </label>


### PR DESCRIPTION
This is a WIP. 

Starts to fix https://github.com/dobtco/screendoor-v2/issues/4465

This will add a static label to the file upload with a disclaimer for the max file size. 

ref this slack message for max file size nginx config: https://dobt.slack.com/archives/C024ZNYSG/p1523998480000159

current attempt:
![screen shot 2018-04-24 at 13 48 31](https://user-images.githubusercontent.com/30604969/39207946-f66ca022-47c6-11e8-827c-2fa7aae3b822.png)

todos: 
- [ ] wording
- [ ] translation
- [ ] placement
- [ ] flag to show this always / only on error etc.
